### PR TITLE
Dump configuration to a file

### DIFF
--- a/confit.py
+++ b/confit.py
@@ -635,11 +635,11 @@ class Dumper(yaml.SafeDumper):
         (i.e. comma separated, within square brackets).
         """
         node = super(Dumper, self).represent_list(data)
-        #import ipdb
-        #ipdb.set_trace()
         length = len(data)
         if self.default_flow_style is None and length < 4:
             node.flow_style = True
+        elif self.default_flow_style is None:
+            node.flow_style = False
         return node
 
     def represent_bool(self, data):


### PR DESCRIPTION
These changes add a way to dump a Configuration to a file.
The order of the keys, comments and newlines from the default configuration are all preserved.

It is capable of doing a roundtrip with the configuration of the example while preserving almost 100% of the original formatting. The only thing that changes at the moment is the format of scalars, here YAML chooses the most restricted form for the value, i.e. no quotes when there are no special characters or escaping, single quotes if there is.
