### PR TITLE
Include test/__init__.py in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,9 @@ include README.rst
 recursive-include docs *.rst *.py Makefile *.png
 prune docs/_build
 
+# Include tests without pyc etc.
+prune test
+include test/*.py
+
 # Exclude junk.
 global-exclude .DS_Store


### PR DESCRIPTION
Without this file tests can't be run directly from the unpacked sdist tarball. Closes #54.