### PR TITLE
Correct doc typo `parse_args` → `set_args`.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -175,7 +175,7 @@ have dot-delimited properties on the incoming object.::
     config.set_args(args, dots=True)
     print(config['foo']['bar'].get())
 
-`parse_args` works with generic dictionaries too.::
+`set_args` works with generic dictionaries too.::
 
     args = {
       'foo': {


### PR DESCRIPTION
The docs say `parse_args`, but they mean to refer to `set_args`.