### PR TITLE
Add `as_str_expanded()` conversion method.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -121,6 +121,10 @@ conversion:
   value``) and, unlike real mappings, preserve order.
 * ``as_str_seq()``: Given either a string or a list of strings, return a list
   of strings. A single string is split on whitespace.
+* ``as_str_expanded()``: Expand any environment variables contained in
+  a string using `os.path.expandvars()`_.
+
+.. _os.path.expandvars(): https://docs.python.org/library/os.path.html#os.path.expandvars
 
 For example, ``config['path'].as_filename()`` ensures that you get a
 reasonable filename string from the configuration. And calling

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -141,6 +141,11 @@ class BuiltInValidatorTest(unittest.TestCase):
         with self.assertRaises(confuse.ConfigTypeError):
             config['f'].as_str()
 
+    def test_as_str_expanded(self):
+        config = _root({'s': '${CONFUSE_TEST_VAR}/bar'})
+        os.environ["CONFUSE_TEST_VAR"] = 'foo'
+        self.assertEqual(config['s'].as_str_expanded(), 'foo/bar')
+
     def test_as_pairs(self):
         config = _root({'k': [{'a': 'A'}, 'b', ['c', 'C']]})
         self.assertEqual(


### PR DESCRIPTION
Somewhat akin to `as_filename()`, this method validates the value as a `String` and then calls `os.path.expandvars()` to expand any environment variables contained therein.

`os.path.expandvars()` works with the env vars on Unixlike and Windows platforms.

https://docs.python.org/3/library/os.path.html#os.path.expandvars

---

I thought about implementing this as a new template, like `Filename`. But since the amount of logic is so tiny, and it is a strict superset of the `String` template, it seemed better to just reuse the `String` template.