### PR TITLE
a slightly better version of restore_yaml_comments

### DIFF
--- a/confuse.py
+++ b/confuse.py
@@ -861,29 +861,33 @@ def restore_yaml_comments(data, default_data):
     Only works with comments that are on one or more own lines, i.e.
     not next to a yaml mapping.
     """
-    comment_map = dict()
-    default_lines = iter(default_data.splitlines())
-    for line in default_lines:
+
+    def has_comment(line):
         if not line:
-            comment = "\n"
-        elif line.startswith("#"):
-            comment = "{0}\n".format(line)
+            return True
+        elif re.match("^\s*#.*$", line):
+            return True
         else:
-            continue
-        while True:
-            line = next(default_lines)
-            if line and not line.startswith("#"):
-                break
-            comment += "{0}\n".format(line)
-        key = line.split(':')[0].strip()
-        comment_map[key] = comment
-    out_lines = iter(data.splitlines())
+            return False
+
+    comment = ""
     out_data = ""
-    for line in out_lines:
-        key = line.split(':')[0].strip()
-        if key in comment_map:
-            out_data += comment_map[key]
-        out_data += "{0}\n".format(line)
+    default_lines = iter(default_data.splitlines())
+    out_lines = iter(data.splitlines())
+
+    for line in default_lines:
+        if has_comment(line):
+            comment += "{0}\n".format(line)
+        else:
+            out_data += comment
+            comment = ""
+            key = line.split(':')[0].strip()
+            out_line = next(out_lines)
+            while key != out_line.split(':')[0].strip():
+                out_data += "{0}\n".format(out_line)
+                out_line = next(out_lines)
+            out_data += "{0}\n".format(out_line)
+    out_data += comment
     return out_data
 
 


### PR DESCRIPTION
I discovered that config.dump() throws StopIteration if my config_default.yaml has comments in the end of the file.

The reason was how original restore_yaml_comments() processed default_data.
Also, original restore_yaml_comments() would put a comment in front of ALL the keys with the same name.
And if a comment was indented, the original restore_yaml_comments() ignored it.

I made some changes that fix these three problems.

It is not ideal - for example, it does not align indentation and I imagine a case where it would misplace a comment, but it improves current implementation.