### PR TITLE
fix Configuration.dump() documentation

### DIFF
--- a/confuse.py
+++ b/confuse.py
@@ -1005,9 +1005,6 @@ class Configuration(RootView):
         configuration file. All keys not in the default configuration
         will be appended to the end of the file.
 
-        :param filename:  The file to dump the configuration to, or None
-                          if the YAML string should be returned instead
-        :type filename:   unicode
         :param full:      Dump settings that don't differ from the defaults
                           as well
         :param redact:    Remove sensitive information (views with the `redact`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -302,9 +302,8 @@ niceties suited to human-written configuration files. Those tweaks are:
 
 .. _OrderedDict: http://docs.python.org/2/library/collections.html#collections.OrderedDict
 
-To produce a YAML file reflecting a configuration, just call
-``config.dump()``. If you supply a filename, the YAML will be written to the
-file; otherwise, a string is returned. This does not cleanly round-trip YAML,
+To produce a YAML string reflecting a configuration, just call
+``config.dump()``. This does not cleanly round-trip YAML,
 but it does play some tricks to preserve comments and spacing in the original
 file.
 


### PR DESCRIPTION
It doesn't accept `filename` anymore. Fixes #47.