### PR TITLE
add support for pathlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
     include:
         - python: 2.7
           env: {TOXENV: py27-test}
-        - python: 3.4
-          env: {TOXENV: py34-cov, COVERAGE: 1}
         - python: 3.5
           env: {TOXENV: py35-test}
         - python: 3.6
@@ -20,8 +18,6 @@ matrix:
           env: {TOXENV: pypy-test}
         - python: 2.7
           env: {TOXENV: py27-flake8}
-        - python: 3.4
-          env: {TOXENV: py34-flake8}
         - python: 3.6
           env: {TOXENV: py36-flake8}
         - python: 2.7

--- a/confuse.py
+++ b/confuse.py
@@ -486,6 +486,11 @@ class ConfigView(object):
         """
         return self.get(Filename())
 
+    def as_path(self):
+        """Get the value as a `pathlib.Path` object. Equivalent to `get(Path())`.
+        """
+        return self.get(Path())
+
     def as_choice(self, choices):
         """Get the value from a list of choices. Equivalent to
         `get(Choice(choices))`.
@@ -1598,6 +1603,20 @@ class Filename(Template):
                 path = os.path.join(view.root().config_dir(), path)
 
         return os.path.abspath(path)
+
+
+class Path(Filename):
+    """A template that validates strings as `pathlib.Path` objects.
+
+    Filenames are parsed equivalent to the `Filename` template and then
+    converted to `pathlib.Path` objects.
+
+    For Python 2 it returns the original path as returned by the `Filename`
+    template.
+    """
+    def value(self, view, template=None):
+        import pathlib
+        return pathlib.Path(super(Path, self).value(view, template))
 
 
 class TypeTemplate(Template):

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -62,6 +62,19 @@ class BuiltInValidatorTest(unittest.TestCase):
         with self.assertRaises(confuse.ConfigTypeError):
             config['foo'].as_filename()
 
+    def test_as_path(self):
+        config = _root({'foo': 'foo/bar'})
+        path = os.path.join(os.getcwd(), 'foo', 'bar')
+        try:
+            import pathlib
+        except ImportError:
+            with self.assertRaises(ImportError):
+                value = config['foo'].as_path()
+        else:
+            value = config['foo'].as_path()
+            path = pathlib.Path(path)
+            self.assertEqual(value, path)
+
     def test_as_choice_correct(self):
         config = _root({'foo': 'bar'})
         value = config['foo'].as_choice(['foo', 'bar', 'baz'])


### PR DESCRIPTION
Using pathlib in Python3 is a convenient way to handle paths, so this little extra is added to augment the already very nice path handling mechanism of the Filename template.

