### PR TITLE
added filename default values

### DIFF
--- a/confuse.py
+++ b/confuse.py
@@ -1125,15 +1125,21 @@ class Template(object):
         May raise a `NotFoundError` if the value is missing (and the
         template requires it) or a `ConfigValueError` for invalid values.
         """
-        if view.exists():
+        try:
             value, _ = view.first()
             return self.convert(value, view)
-        elif self.default is REQUIRED:
+        except NotFoundError:
+            pass
+
+        # get default value, raise if required
+        return self.get_default_value(view.name)
+
+    def get_default_value(self, key_name='default'):
+        if self.default is REQUIRED:
             # Missing required value. This is an error.
-            raise NotFoundError(u"{0} not found".format(view.name))
-        else:
-            # Missing value, but not required.
-            return self.default
+            raise NotFoundError(u"{} not found".format(key_name))
+        # Missing value, but not required.
+        return self.default
 
     def convert(self, value, view):
         """Convert the YAML-deserialized value to a value of the desired
@@ -1578,7 +1584,11 @@ class Filename(Template):
         return view.parent.get(next_template)[self.relative_to]
 
     def value(self, view, template=None):
-        path, source = view.first()
+        try:
+            path, source = view.first()
+        except NotFoundError:
+            return self.get_default_value(view.name)
+
         if not isinstance(path, BASESTRING):
             self.fail(
                 u'must be a filename, not {0}'.format(type(path).__name__),
@@ -1615,8 +1625,11 @@ class Path(Filename):
     template.
     """
     def value(self, view, template=None):
+        value = super(Path, self).value(view, template)
+        if value is None:
+            return
         import pathlib
-        return pathlib.Path(super(Path, self).value(view, template))
+        return pathlib.Path(value)
 
 
 class TypeTemplate(Template):

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     long_description=_read("README.rst"),
     long_description_content_type='text/x-rst',
     install_requires=['pyyaml'],
-    tests_require=['tox'],
+    tests_require=['tox', 'pathlib'],
     py_modules=['confuse'],
     cmdclass={'test': test},
     classifiers=[

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -453,7 +453,6 @@ class PathTest(unittest.TestCase):
             config['foo'].get(confuse.Path())
 
 
-
 class BaseTemplateTest(unittest.TestCase):
     def test_base_template_accepts_any_value(self):
         config = _root({'foo': 4.2})

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -337,6 +337,21 @@ class StrSeqTest(unittest.TestCase):
 
 
 class FilenameTest(unittest.TestCase):
+    def test_default_value(self):
+        config = _root({})
+        valid = config['foo'].get(confuse.Filename('foo/bar'))
+        self.assertEqual(valid, 'foo/bar')
+
+    def test_default_none(self):
+        config = _root({})
+        valid = config['foo'].get(confuse.Filename(None))
+        self.assertEqual(valid, None)
+
+    def test_missing_required_value(self):
+        config = _root({})
+        with self.assertRaises(confuse.NotFoundError):
+            config['foo'].get(confuse.Filename())
+
     def test_filename_relative_to_working_dir(self):
         config = _root({'foo': 'bar'})
         valid = config['foo'].get(confuse.Filename(cwd='/dev/null'))
@@ -412,6 +427,31 @@ class FilenameTest(unittest.TestCase):
         config = _root({'foo': 8})
         with self.assertRaises(confuse.ConfigTypeError):
             config['foo'].get(confuse.Filename())
+
+
+class PathTest(unittest.TestCase):
+    def test_path_value(self):
+        import pathlib
+        config = _root({'foo': 'foo/bar'})
+        valid = config['foo'].get(confuse.Path())
+        self.assertEqual(valid, pathlib.Path(os.path.abspath('foo/bar')))
+
+    def test_default_value(self):
+        import pathlib
+        config = _root({})
+        valid = config['foo'].get(confuse.Path('foo/bar'))
+        self.assertEqual(valid, pathlib.Path('foo/bar'))
+
+    def test_default_none(self):
+        config = _root({})
+        valid = config['foo'].get(confuse.Path(None))
+        self.assertEqual(valid, None)
+
+    def test_missing_required_value(self):
+        config = _root({})
+        with self.assertRaises(confuse.NotFoundError):
+            config['foo'].get(confuse.Path())
+
 
 
 class BaseTemplateTest(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     nose
     nose-show-skipped
     pyyaml
+    pathlib
 
 
 [_flake8]


### PR DESCRIPTION
fix #77 #76 

Notes:
 - it returns the default value as is. it won't do any conversions to the default (path joins) which is in line with how other templates implement it.
 - this also allows filenames to have other default values (e.g. None, False)
 - `confuse.Path` extends `confuse.Filename` meaning it can also use default values. If the default value is None, it will return None, otherwise it will try to convert to path.