### PR TITLE
Use None as template default

### DIFF
--- a/confuse/core.py
+++ b/confuse/core.py
@@ -331,7 +331,7 @@ class ConfigView(object):
                     od[key] = view.get()
         return od
 
-    def get(self, template=None):
+    def get(self, template=confuse.REQUIRED):
         """Retrieve the value for this view according to the template.
 
         The `template` against which the values are checked can be

--- a/confuse/core.py
+++ b/confuse/core.py
@@ -335,7 +335,7 @@ class ConfigView(object):
                     od[key] = view.get()
         return od
 
-    def get(self, template=confuse.REQUIRED):
+    def get(self, template=templates.REQUIRED):
         """Retrieve the value for this view according to the template.
 
         The `template` against which the values are checked can be

--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -627,7 +627,7 @@ def as_template(value):
         return Number(value)
     elif value is None:
         return Template(None)
-    elif value is confuse.REQUIRED:
+    elif value is REQUIRED:
         return Template()
     elif value is dict:
         return TypeTemplate(abc.Mapping)

--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -625,6 +625,8 @@ def as_template(value):
     elif isinstance(value, float):
         return Number(value)
     elif value is None:
+        return Template(None)
+    elif value is confuse.REQUIRED:
         return Template()
     elif value is dict:
         return TypeTemplate(abc.Mapping)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -393,6 +393,10 @@ v1.3.0
 
 - Break up the `confuse` module into a package. (All names should still be
   importable from `confuse`.)
+- When using `None` as a template, the result is a value whose default is
+  `None`. Previously, this was equivalent to leaving the key off entirely,
+  i.e., a template with no default. To get the same effect now, use
+  `confuse.REQUIRED` in the template.
 
 v1.2.0
 ''''''

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -173,6 +173,11 @@ class AsTemplateTest(unittest.TestCase):
         self.assertIs(type(typ), confuse.Template)
         self.assertEqual(typ.default, None)
 
+    def test_required_as_template(self):
+        typ = confuse.as_template(confuse.REQUIRED)
+        self.assertIs(type(typ), confuse.Template)
+        self.assertEqual(typ.default, confuse.REQUIRED)
+
     def test_dict_type_as_template(self):
         typ = confuse.as_template(dict)
         self.assertIsInstance(typ, confuse.TypeTemplate)

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -171,7 +171,7 @@ class AsTemplateTest(unittest.TestCase):
     def test_none_as_template(self):
         typ = confuse.as_template(None)
         self.assertIs(type(typ), confuse.Template)
-        self.assertEqual(typ.default, confuse.REQUIRED)
+        self.assertEqual(typ.default, None)
 
     def test_dict_type_as_template(self):
         typ = confuse.as_template(dict)


### PR DESCRIPTION
Fixes #93

In order to have a required config option (previous behavior), use `confuse.REQUIRED` or `confuse.Template()`

PR #95 should be merged first and then the diffs will be readable.