### PR TITLE
Refactor YAML loading into `YamlSource` class

### DIFF
--- a/confuse/core.py
+++ b/confuse/core.py
@@ -24,7 +24,7 @@ from collections import OrderedDict
 from . import util
 from . import templates
 from . import yaml_util
-from .sources import ConfigSource
+from .sources import ConfigSource, YamlSource
 from .exceptions import ConfigTypeError, NotFoundError, ConfigError
 
 CONFIG_FILENAME = 'config.yaml'
@@ -571,9 +571,7 @@ class Configuration(RootView):
         """
         filename = self.user_config_path()
         if os.path.isfile(filename):
-            yaml_data = yaml_util.load_yaml(filename, loader=self.loader) \
-                or {}
-            self.add(ConfigSource(yaml_data, filename))
+            self.add(YamlSource(filename, loader=self.loader))
 
     def _add_default_source(self):
         """Add the package's default configuration settings. This looks
@@ -584,11 +582,8 @@ class Configuration(RootView):
             if self._package_path:
                 filename = os.path.join(self._package_path, DEFAULT_FILENAME)
                 if os.path.isfile(filename):
-                    yaml_data = yaml_util.load_yaml(
-                        filename,
-                        loader=self.loader,
-                    )
-                    self.add(ConfigSource(yaml_data, filename, True))
+                    self.add(YamlSource(filename, loader=self.loader,
+                                        default=True))
 
     def read(self, user=True, defaults=True):
         """Find and read the files for this configuration and set them
@@ -642,8 +637,7 @@ class Configuration(RootView):
         sources with highest priority.
         """
         filename = os.path.abspath(filename)
-        yaml_data = yaml_util.load_yaml(filename, loader=self.loader)
-        self.set(ConfigSource(yaml_data, filename))
+        self.set(YamlSource(filename, loader=self.loader))
 
     def dump(self, full=True, redact=False):
         """Dump the Configuration object to a YAML file.

--- a/confuse/core.py
+++ b/confuse/core.py
@@ -570,8 +570,7 @@ class Configuration(RootView):
         exists.
         """
         filename = self.user_config_path()
-        if os.path.isfile(filename):
-            self.add(YamlSource(filename, loader=self.loader))
+        self.add(YamlSource(filename, loader=self.loader, optional=True))
 
     def _add_default_source(self):
         """Add the package's default configuration settings. This looks
@@ -581,9 +580,8 @@ class Configuration(RootView):
         if self.modname:
             if self._package_path:
                 filename = os.path.join(self._package_path, DEFAULT_FILENAME)
-                if os.path.isfile(filename):
-                    self.add(YamlSource(filename, loader=self.loader,
-                                        default=True))
+                self.add(YamlSource(filename, loader=self.loader,
+                                    optional=True, default=True))
 
     def read(self, user=True, defaults=True):
         """Find and read the files for this configuration and set them

--- a/confuse/core.py
+++ b/confuse/core.py
@@ -634,7 +634,6 @@ class Configuration(RootView):
         """Parses the file as YAML and inserts it into the configuration
         sources with highest priority.
         """
-        filename = os.path.abspath(filename)
         self.set(YamlSource(filename, loader=self.loader))
 
     def dump(self, full=True, redact=False):

--- a/confuse/sources.py
+++ b/confuse/sources.py
@@ -51,6 +51,7 @@ class YamlSource(ConfigSource):
         file does not exist---instead, the source will be silently
         empty.
         """
+        filename = os.path.abspath(filename)
         if optional and not os.path.isfile(filename):
             value = {}
         else:

--- a/confuse/sources.py
+++ b/confuse/sources.py
@@ -4,8 +4,6 @@ from .util import BASESTRING
 from . import yaml_util
 import os
 
-__all__ = ['ConfigSource']
-
 
 class ConfigSource(dict):
     """A dictionary augmented with metadata about the source of the

--- a/confuse/sources.py
+++ b/confuse/sources.py
@@ -2,6 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 from .util import BASESTRING
 from . import yaml_util
+import os
 
 __all__ = ['ConfigSource']
 
@@ -45,5 +46,15 @@ class YamlSource(ConfigSource):
 
     def __init__(self, filename=None, default=False,
                  optional=False, loader=yaml_util.Loader):
-        value = yaml_util.load_yaml(filename, loader=loader) or {}
+        """Create a YAML data source by reading data from a file.
+
+        May raise a `ConfigReadError`. However, if `optional` is
+        enabled, this exception will not be raised in the case when the
+        file does not exist---instead, the source will be silently
+        empty.
+        """
+        if optional and not os.path.isfile(filename):
+            value = {}
+        else:
+            value = yaml_util.load_yaml(filename, loader=loader) or {}
         super(YamlSource, self).__init__(value, filename, default)

--- a/confuse/sources.py
+++ b/confuse/sources.py
@@ -1,6 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
 from .util import BASESTRING
+from . import yaml_util
 
 __all__ = ['ConfigSource']
 
@@ -36,3 +37,13 @@ class ConfigSource(dict):
             return ConfigSource(value)
         else:
             raise TypeError(u'source value must be a dict')
+
+
+class YamlSource(ConfigSource):
+    """A configuration data source that reads from a YAML file.
+    """
+
+    def __init__(self, filename=None, default=False,
+                 optional=False, loader=yaml_util.Loader):
+        value = yaml_util.load_yaml(filename, loader=loader) or {}
+        super(YamlSource, self).__init__(value, filename, default)


### PR DESCRIPTION
This is the first step of #96 and @beasteers's approach to lazy source loading. (As a quick recap, that idea is to refactor laziness into the *source* instead of the *configuration* object, which is both cleaner and enables mixing-and-matching of lazy and eager sources within the same config.)

This step just consists of an innocuous but nice refactoring to use a `YamlSource` class to encapsulate the vagaries of loading configuration data from a file. The next step would be to introduce a lazy option here: either a `lazy` parameter to the `YamlSource` constructor or a separate `LazyYamlSource` class (or similar).
