### PR TITLE
Add Auto-Generated API Docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,53 @@
+=================
+API Documentation
+=================
+
+This part of the documentation covers the interfaces used to develop with :code:`confuse`.
+
+Core
+----
+
+.. automodule:: confuse.core
+    :members:
+    :private-members:
+    :show-inheritance:
+
+Exceptions
+----------
+
+.. automodule:: confuse.exceptions
+    :members:
+    :private-members:
+    :show-inheritance:
+
+Sources
+-------
+
+.. automodule:: confuse.sources
+    :members:
+    :private-members:
+    :show-inheritance:
+
+Templates
+---------
+
+.. automodule:: confuse.templates
+    :members:
+    :private-members:
+    :show-inheritance:
+
+Utility
+-------
+
+.. automodule:: confuse.util
+    :members:
+    :private-members:
+    :show-inheritance:
+
+YAML Utility
+------------
+
+.. automodule:: confuse.yaml_util
+    :members:
+    :private-members:
+    :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,9 @@
 from __future__ import division, absolute_import, print_function
 
-
 extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.viewcode',
     'sphinx.ext.autosectionlabel',
 ]
 source_suffix = '.rst'
@@ -21,3 +23,5 @@ pygments_style = 'sphinx'
 
 html_theme = 'default'
 htmlhelp_basename = 'Confusedoc'
+
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -385,6 +385,17 @@ Then flatten or dump the configuration like so::
 The resulting YAML will contain "key: REDACTED" instead of the original data.
 
 
+Dive Deeper
+-----------
+
+For more advanced usage, dive deeper in to the API documentation.
+
+.. toctree::
+   :maxdepth: 2
+
+   api
+
+
 Changelog
 ---------
 


### PR DESCRIPTION
This library is great, and even better ya'll have documented the code well. But good documentation shouldn't require digging, and we're already 90% of the way there using Sphinx and ReadTheDocs, so auto-generated the API docs as well.

Speaking from experience, this would help tremendously to bridge the gap between functionality and the limited documentation that is available until more thorough, custom documentation can be built out. Another added bonus is that, with auto-generated API docs (even if you don't want to link to it), other Sphinx projects can natively link to your source documentation (so maybe my motivations here are a little selfish as well).