### PR TITLE
Fix 404 link to Confuse docs from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,6 @@ Like beets, it is available under the `MIT license`_.
 .. _optparse: http://docs.python.org/dev/library/optparse.html
 .. _argparse: http://docs.python.org/dev/library/argparse.html
 .. _logging: http://docs.python.org/library/logging.html
-.. _Confuse's documentation: http://confuse.readthedocs.org/usage.html
+.. _Confuse's documentation: http://confuse.readthedocs.org/en/latest/usage.html
 .. _MIT license: http://www.opensource.org/licenses/mit-license.php
 .. _beets: https://github.com/beetbox/beets


### PR DESCRIPTION
Addresses issue raised on #114. Can hold off on merging until the creator replies to confirm if there are other issues to fix in this same PR or not. Didn't see any other broken links myself, but they referenced some, so waiting to hear back about more specifics.