### PR TITLE
Make attributes in AttrDict properly writable

### DIFF
--- a/confuse/__init__.py
+++ b/confuse/__init__.py
@@ -3,7 +3,7 @@
 
 from __future__ import division, absolute_import, print_function
 
-__version__ = '1.3.0'
+__version__ = '1.5.0'
 
 from .exceptions import * # NOQA
 from .util import * # NOQA

--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -601,6 +601,9 @@ class AttrDict(dict):
         else:
             raise AttributeError(key)
 
+    def __setattr__(self, key, value):
+        self[key] = value
+
 
 def as_template(value):
     """Convert a simple "shorthand" Python value to a `Template`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,8 +16,8 @@ master_doc = 'index'
 project = u'Confuse'
 copyright = u'2012, Adrian Sampson'
 
-version = '1.3'
-release = '1.3.0'
+version = '1.5'
+release = '1.5.0'
 
 exclude_patterns = ['_build']
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -418,6 +418,11 @@ The resulting YAML will contain "key: REDACTED" instead of the original data.
 Changelog
 ---------
 
+v1.5.0
+''''''
+
+- `AttrDict` now properly supports (over)writing attributes via dot notation.
+
 v1.4.0
 ''''''
 


### PR DESCRIPTION
`AttrDict(dict)` is a very convenient class for accessing confuse dictionaries using attribute style notation, e.g. `valid.paths.directory`. 

However, you cannot use attribute style notation to (over)write attributes. For example `valid.paths.directory = "C:/"` will not work as expected. It will create a new attribute `directory` in `valid.paths`. This is because the set statement accesses `directory` in subclass `AttrDict`, not the `dict` base class. To overwrite the existing attribute, you have to write `valid['paths']['directory'] = "C:/"` instead :(.

This pull request solves that problem by writing attributes to the base class.