### PR TITLE
Add options for Filename templates to resolve relative paths using source file location

### DIFF
--- a/confuse/core.py
+++ b/confuse/core.py
@@ -649,11 +649,12 @@ class Configuration(RootView):
             os.makedirs(appdir)
         return appdir
 
-    def set_file(self, filename):
+    def set_file(self, filename, base_for_paths=False):
         """Parses the file as YAML and inserts it into the configuration
         sources with highest priority.
         """
-        self.set(YamlSource(filename, loader=self.loader))
+        self.set(YamlSource(filename, base_for_paths=base_for_paths,
+                            loader=self.loader))
 
     def dump(self, full=True, redact=False):
         """Dump the Configuration object to a YAML file.

--- a/confuse/core.py
+++ b/confuse/core.py
@@ -652,6 +652,12 @@ class Configuration(RootView):
     def set_file(self, filename, base_for_paths=False):
         """Parses the file as YAML and inserts it into the configuration
         sources with highest priority.
+
+        :param filename: Filename of the YAML file to load.
+        :param base_for_paths: Indicates whether the directory containing the
+            YAML file will be used as the base directory for resolving relative
+            path values stored in the YAML file. Otherwise, by default, the
+            directory returned by `config_dir()` will be used as the base.
         """
         self.set(YamlSource(filename, base_for_paths=base_for_paths,
                             loader=self.loader))

--- a/confuse/sources.py
+++ b/confuse/sources.py
@@ -9,19 +9,22 @@ class ConfigSource(dict):
     """A dictionary augmented with metadata about the source of the
     configuration.
     """
-    def __init__(self, value, filename=None, default=False):
+    def __init__(self, value, filename=None, default=False,
+                 base_for_paths=False):
         super(ConfigSource, self).__init__(value)
         if (filename is not None
                 and not isinstance(filename, BASESTRING)):
             raise TypeError(u'filename must be a string or None')
         self.filename = filename
         self.default = default
+        self.base_for_paths = base_for_paths
 
     def __repr__(self):
-        return 'ConfigSource({0!r}, {1!r}, {2!r})'.format(
+        return 'ConfigSource({0!r}, {1!r}, {2!r}, {3!r})'.format(
             super(ConfigSource, self),
             self.filename,
             self.default,
+            self.base_for_paths,
         )
 
     @classmethod
@@ -42,7 +45,7 @@ class YamlSource(ConfigSource):
     """A configuration data source that reads from a YAML file.
     """
 
-    def __init__(self, filename=None, default=False,
+    def __init__(self, filename=None, default=False, base_for_paths=False,
                  optional=False, loader=yaml_util.Loader):
         """Create a YAML data source by reading data from a file.
 
@@ -52,7 +55,7 @@ class YamlSource(ConfigSource):
         empty.
         """
         filename = os.path.abspath(filename)
-        super(YamlSource, self).__init__({}, filename, default)
+        super(YamlSource, self).__init__({}, filename, default, base_for_paths)
         self.loader = loader
         self.optional = optional
         self.load()

--- a/confuse/sources.py
+++ b/confuse/sources.py
@@ -11,6 +11,21 @@ class ConfigSource(dict):
     """
     def __init__(self, value, filename=None, default=False,
                  base_for_paths=False):
+        """Create a configuration source from a dictionary.
+
+        :param filename: The file with the data for this configuration source.
+
+        :param default: Indicates whether this source provides the
+            application's default configuration settings.
+
+        :param base_for_paths: Indicates whether the source file's directory
+        (i.e., the directory component of `self.filename`) should be used as
+        the base directory for resolving relative path values provided by this
+        source, instead of using the application's configuration directory. If
+        no `filename` is provided, `base_for_paths` will be treated as False.
+        See `templates.Filename` for details of the relative path resolution
+        behavior.
+        """
         super(ConfigSource, self).__init__(value)
         if (filename is not None
                 and not isinstance(filename, BASESTRING)):

--- a/confuse/sources.py
+++ b/confuse/sources.py
@@ -17,7 +17,7 @@ class ConfigSource(dict):
             raise TypeError(u'filename must be a string or None')
         self.filename = filename
         self.default = default
-        self.base_for_paths = base_for_paths
+        self.base_for_paths = base_for_paths if filename is not None else False
 
     def __repr__(self):
         return 'ConfigSource({0!r}, {1!r}, {2!r}, {3!r})'.format(

--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -431,10 +431,13 @@ class Filename(Template):
     Filenames are returned as absolute, tilde-free paths.
 
     Relative paths are relative to the template's `cwd` argument
-    when it is specified, then the configuration directory (see
-    the `config_dir` method) if they come from a file. Otherwise,
-    they are relative to the current working directory. This helps
-    attain the expected behavior when using command-line options.
+    when it is specified. Otherwise, if the paths come from a file,
+    they will be relative to the configuration directory (see the
+    `config_dir` method) by default or to the base directory of the
+    config file if the source has `base_for_paths` set to True.
+    Paths from sources without a file are relative to the current
+    working directory. This helps attain the expected behavior when
+    using command-line options.
     """
     def __init__(self, default=REQUIRED, cwd=None, relative_to=None,
                  in_app_dir=False):
@@ -542,6 +545,10 @@ class Filename(Template):
                     self.resolve_relative_to(view, template),
                     path,
                 )
+
+            elif source.base_for_paths and source.filename:
+                # relative to the directory the source file is in.
+                path = os.path.join(os.path.dirname(source.filename), path)
 
             elif source.filename or self.in_app_dir:
                 # From defaults: relative to the app's directory.

--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -434,24 +434,29 @@ class Filename(Template):
     when it is specified. Otherwise, if the paths come from a file,
     they will be relative to the configuration directory (see the
     `config_dir` method) by default or to the base directory of the
-    config file if the source has `base_for_paths` set to True.
-    Paths from sources without a file are relative to the current
-    working directory. This helps attain the expected behavior when
-    using command-line options.
+    config file if either the source has `base_for_paths` set to True
+    or the template has `in_source_dir` set to True. Paths from sources
+    without a file are relative to the current working directory. This
+    helps attain the expected behavior when using command-line options.
     """
     def __init__(self, default=REQUIRED, cwd=None, relative_to=None,
-                 in_app_dir=False):
+                 in_app_dir=False, in_source_dir=False):
         """`relative_to` is the name of a sibling value that is
         being validated at the same time.
 
         `in_app_dir` indicates whether the path should be resolved
         inside the application's config directory (even when the setting
         does not come from a file).
+
+        `in_source_dir` indicates whether the path should be resolved
+        relative to the directory containing the source file, if there is
+        one, taking precedence over the application's config directory.
         """
         super(Filename, self).__init__(default)
         self.cwd = cwd
         self.relative_to = relative_to
         self.in_app_dir = in_app_dir
+        self.in_source_dir = in_source_dir
 
     def __repr__(self):
         args = []
@@ -546,7 +551,8 @@ class Filename(Template):
                     path,
                 )
 
-            elif source.base_for_paths and source.filename:
+            elif source.filename and (source.base_for_paths
+                                      or self.in_source_dir):
                 # relative to the directory the source file is in.
                 path = os.path.join(os.path.dirname(source.filename), path)
 

--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -504,6 +504,9 @@ class Filename(Template):
         if self.in_app_dir:
             args.append('in_app_dir=True')
 
+        if self.in_source_dir:
+            args.append('in_source_dir=True')
+
         return 'Filename({0})'.format(', '.join(args))
 
     def resolve_relative_to(self, view, template):
@@ -582,8 +585,8 @@ class Filename(Template):
                     path,
                 )
 
-            elif source.filename and (source.base_for_paths
-                                      or self.in_source_dir):
+            elif ((source.filename and self.in_source_dir)
+                  or (source.base_for_paths and not self.in_app_dir)):
                 # relative to the directory the source file is in.
                 path = os.path.join(os.path.dirname(source.filename), path)
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -75,7 +75,7 @@ Using views, you can write ``config['animal_counts'][8]`` and know that
 no exceptions will be raised until you call ``get()``, even if the
 ``animal_counts`` key does not exist. More importantly, it lets you
 write a single expression to search many different data sources without
-preemtively merging all sources together into a single data structure.
+preemptively merging all sources together into a single data structure.
 
 Views also solve an important problem with overriding collections.
 Imagine, for example, that you have a dictionary called
@@ -109,13 +109,15 @@ few methods on views that perform fancier validation or even
 conversion:
 
 * ``as_filename()``: Normalize a filename, substituting tildes and
-  absolute-ifying relative paths. The filename is relative to the source
-  that provided it. That is, a relative path in a config file refers to
-  the directory containing the config file. A relative path in the
-  defaults refers to the application's config directory
-  (``config.config_dir()``, as described below). A relative path from
-  any other source (e.g., command-line options) is relative to the
-  working directory.
+  absolute-ifying relative paths. For filenames defined in a config file,
+  by default the filename is relative to the application's config directory
+  (``Configuration.config_dir()``, as described below). However, if the config
+  file was loaded with the ``base_for_paths`` parameter set to ``True``
+  (see :ref:`Manually Specifying Config Files`), then a relative path refers
+  to the directory containing the config file. A relative path from any other
+  source (e.g., command-line options) is relative to the working directory. For
+  full control over relative path resolution, use the ``Filename`` template
+  directly.
 * ``as_choice(choices)``: Check that a value is one of the provided
   choices. The argument should be a sequence of possible values. If the
   sequence is a ``dict``, then this method returns the associated value
@@ -251,18 +253,22 @@ Manually Specifying Config Files
 --------------------------------
 
 You may want to leverage Confuse's features without :ref:`Search Paths`.
-This can be done by manually specifying the YAML files you want to include:
+This can be done by manually specifying the YAML files you want to include,
+which also allows changing how relative paths in the file will be resolved:
 
 .. code-block:: python
 
     import confuse
     # Instantiates config. Confuse searches for a config_default.yaml
     config = confuse.Configuration('MyGreatApp', __name__)
-    # Add config items from specified file
+    # Add config items from specified file. Relative path values within the
+    # file are resolved relative to the application's configuration directory.
     config.set_file('subdirectory/default_config.yaml')
     # Add config items from a second file. If some items were already defined,
-    # they will be overwritten (new file precedes the previous ones)
-    config.set_file('subdirectory/local_config.yaml')
+    # they will be overwritten (new file precedes the previous ones). With
+    # `base_for_paths` set to True, relative path values in this file will be
+    # resolved relative to the config file's directory (i.e., 'subdirectory').
+    config.set_file('subdirectory/local_config.yaml', base_for_paths=True)
 
     val = config['foo']['bar'].get(int)
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -117,7 +117,7 @@ conversion:
   to the directory containing the config file. A relative path from any other
   source (e.g., command-line options) is relative to the working directory. For
   full control over relative path resolution, use the ``Filename`` template
-  directly.
+  directly (see :ref:`Filename`).
 * ``as_choice(choices)``: Check that a value is one of the provided
   choices. The argument should be a sequence of possible values. If the
   sequence is a ``dict``, then this method returns the associated value

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -450,6 +450,31 @@ class FilenameTest(unittest.TestCase):
         valid = config['foo'].get(confuse.Filename(in_source_dir=True))
         self.assertEqual(valid, os.path.realpath('/baz/foo/bar'))
 
+    def test_filename_in_source_dir_overrides_in_app_dir(self):
+        source = confuse.ConfigSource({'foo': 'foo/bar'},
+                                      filename='/baz/config.yaml')
+        config = _root(source)
+        config.config_dir = lambda: '/config/path'
+        valid = config['foo'].get(confuse.Filename(in_source_dir=True,
+                                                   in_app_dir=True))
+        self.assertEqual(valid, os.path.realpath('/baz/foo/bar'))
+
+    def test_filename_in_app_dir_non_file_source(self):
+        source = confuse.ConfigSource({'foo': 'foo/bar'})
+        config = _root(source)
+        config.config_dir = lambda: '/config/path'
+        valid = config['foo'].get(confuse.Filename(in_app_dir=True))
+        self.assertEqual(valid, os.path.realpath('/config/path/foo/bar'))
+
+    def test_filename_in_app_dir_overrides_config_source_dir(self):
+        source = confuse.ConfigSource({'foo': 'foo/bar'},
+                                      filename='/baz/config.yaml',
+                                      base_for_paths=True)
+        config = _root(source)
+        config.config_dir = lambda: '/config/path'
+        valid = config['foo'].get(confuse.Filename(in_app_dir=True))
+        self.assertEqual(valid, os.path.realpath('/config/path/foo/bar'))
+
     def test_filename_wrong_type(self):
         config = _root({'foo': 8})
         with self.assertRaises(confuse.ConfigTypeError):

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -442,6 +442,14 @@ class FilenameTest(unittest.TestCase):
         valid = config['foo'].get(confuse.Filename())
         self.assertEqual(valid, os.path.realpath('/baz/foo/bar'))
 
+    def test_filename_in_source_dir(self):
+        source = confuse.ConfigSource({'foo': 'foo/bar'},
+                                      filename='/baz/config.yaml')
+        config = _root(source)
+        config.config_dir = lambda: '/config/path'
+        valid = config['foo'].get(confuse.Filename(in_source_dir=True))
+        self.assertEqual(valid, os.path.realpath('/baz/foo/bar'))
+
     def test_filename_wrong_type(self):
         config = _root({'foo': 8})
         with self.assertRaises(confuse.ConfigTypeError):

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -433,6 +433,15 @@ class FilenameTest(unittest.TestCase):
         valid = config['foo'].get(confuse.Filename())
         self.assertEqual(valid, os.path.realpath('/config/path/foo/bar'))
 
+    def test_filename_use_config_source_dir(self):
+        source = confuse.ConfigSource({'foo': 'foo/bar'},
+                                      filename='/baz/config.yaml',
+                                      base_for_paths=True)
+        config = _root(source)
+        config.config_dir = lambda: '/config/path'
+        valid = config['foo'].get(confuse.Filename())
+        self.assertEqual(valid, os.path.realpath('/baz/foo/bar'))
+
     def test_filename_wrong_type(self):
         config = _root({'foo': 8})
         with self.assertRaises(confuse.ConfigTypeError):


### PR DESCRIPTION
These two commits allow confuse ConfigSources and Filename templates to be set up to resolve relative paths from the base directory of the configuration file itself, rather than the application's configuration directory. The new behavior is opt-in.

The first commit implements the new relative path behavior at the ConfigSource level, by allowing the source file to be marked as resolving paths relative to its base directory. This was the suggested approach in response to #125.

The second commit provides an additional way to invoke the new relative path behavior at the level of an individual template, regardless of the setting for the source. This could potentially allow applications to have more fine-grained control over path resolution. It would also allow applications to resolve paths in the application's default `config_default.yaml` file relative to that location within the package. This could be useful for packages with default settings that refer to a default data file. However, if it is not desirable to have two ways to invoke the same behavior, the second commit could be dropped.