### PR TITLE
Optional template to allow a value to be null, missing or validated by another template

### DIFF
--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -609,13 +609,14 @@ class Optional(Template):
 
     def __init__(self, subtemplate, default=None, allow_missing=True):
         self.subtemplate = as_template(subtemplate)
-        if (getattr(self.subtemplate, 'default', REQUIRED) is not REQUIRED
-                and default is None):
-            # Subtemplate's default value will be used if present and
-            # no default was passed to Optional
-            self.default = self.subtemplate.default
-        else:
-            self.default = default
+        if default is None:
+            # When no default is passed, try to use the subtemplate's
+            # default value as the default for this template
+            try:
+                default = self.subtemplate.get_default_value()
+            except exceptions.NotFoundError:
+                pass
+        self.default = default
         self.allow_missing = allow_missing
 
     def value(self, view, template=None):

--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -70,10 +70,14 @@ class Template(object):
         return self.get_default_value(view.name)
 
     def get_default_value(self, key_name='default'):
-        if self.default is REQUIRED:
-            # Missing required value. This is an error.
+        """Get the default value to return when the value is missing.
+
+        May raise a `NotFoundError` if the value is required.
+        """
+        if not hasattr(self, 'default') or self.default is REQUIRED:
+            # The value is required. A missing value is an error.
             raise exceptions.NotFoundError(u"{} not found".format(key_name))
-        # Missing value, but not required.
+        # The value is not required.
         return self.default
 
     def convert(self, value, view):


### PR DESCRIPTION
This Optional template can be composed with other templates to permit their values to be null or missing in the configuration. However, if the value is present and not null, it will be validated against the subtemplate. This template addresses #17, as well as the use case described in #45 where an entire mapping section needed to be made optional. The default behavior of Optional allows the value to be missing completely, but this behavior can be changed to require a value to be present by passing `allow_missing` as `False`.

When the configuration value is null/missing, the template will return a default value (None by default). The default value can be set by passing it to Optional itself or to the subtemplate, which allows usage like this:
```
optional_int = config.get(Optional(int, default=10))
```
to be expressed more concisely as this:
```
optional_int = config.get(Optional(10))
``` 

@sampsyo, I'm working on a few other new templates, too. Would you like me to submit them as PRs in parallel or wait until this PR is resolved first?