### PR TITLE
Sequence template updates: fix AttributeError and add examples

### DIFF
--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -180,6 +180,14 @@ class Sequence(Template):
     def value(self, view, template=None):
         """Get a list of items validated against the template.
         """
+        try:
+            collection, _ = view.first()
+        except exceptions.NotFoundError:
+            pass
+        else:
+            if not isinstance(collection, (list, tuple)):
+                self.fail(u'must be a list', view, True)
+
         out = []
         for item in view:
             out.append(self.subtemplate.value(item, self))

--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -180,16 +180,8 @@ class Sequence(Template):
     def value(self, view, template=None):
         """Get a list of items validated against the template.
         """
-        try:
-            collection, _ = view.first()
-        except exceptions.NotFoundError:
-            pass
-        else:
-            if not isinstance(collection, (list, tuple)):
-                self.fail(u'must be a list', view, True)
-
         out = []
-        for item in view:
+        for item in view.sequence():
             out.append(self.subtemplate.value(item, self))
         return out
 

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -524,6 +524,16 @@ class SequenceTest(unittest.TestCase):
                 {'bar': int, 'baz': int}
             ))
 
+    def test_wrong_type(self):
+        config = _root({'foo': {'one': 1, 'two': 2, 'three': 3}})
+        with self.assertRaises(confuse.ConfigTypeError):
+            config['foo'].get(confuse.Sequence(int))
+
+    def test_missing(self):
+        config = _root({'foo': [1, 2, 3]})
+        valid = config['bar'].get(confuse.Sequence(int))
+        self.assertEqual(valid, [])
+
 
 class MappingValuesTest(unittest.TestCase):
     def test_int_dict(self):


### PR DESCRIPTION
This PR provides two updates for the ``Sequence`` template:
1. Fix #105, where ``Sequence`` raises an ``AttributeError`` when attempting to validate a dict. I added a check that the view returns a list or tuple, and if not, a ``ConfigTypeError`` will be raised. The fix retains the current behavior where if the view is missing, then an empty list is returned. Tests were also added for the cases of attempting to validate a dict and for missing views.
2. The documentation was updated to include examples of using the ``Sequence`` template.