### PR TITLE
Add CachedViews

### DIFF
--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -2,7 +2,6 @@ import unittest
 
 import confuse
 from confuse.cache import CachedConfigView, CachedHandle, CachedRootView
-from confuse.exceptions import NotFoundError
 from confuse.templates import Sequence
 
 
@@ -35,9 +34,9 @@ class CachedViewTest(unittest.TestCase):
         handle: CachedHandle = view.get_handle(Sequence(int))
 
         self.config['x'] = {'p': [4, 5]}
-        # new dict doesn't have a 'y' key
-        with self.assertRaises(NotFoundError):
-            handle.get()
+        # new dict doesn't have a 'y' key, but according to the view-theory,
+        # it will get the value from the older view that has been shadowed.
+        self.assertEqual(handle.get(), [1, 2])
 
     def test_missing2(self):
         view: CachedConfigView = self.config['x']['w']
@@ -45,9 +44,7 @@ class CachedViewTest(unittest.TestCase):
         self.assertEqual(handle.get(), 'z')
 
         self.config['x'] = {'y': [4, 5]}
-        # new dict doesn't have a 'w' key
-        with self.assertRaises(NotFoundError):
-            handle.get()
+        self.assertEqual(handle.get(), 'z')
 
     def test_list_update(self):
         view: CachedConfigView = self.config['a'][1]


### PR DESCRIPTION
## Motivation
* Over at [trakt-scrobbler](https://github.com/iamkroot/trakt-scrobbler), some of my confuse templates are getting more and more computationally expensive. Example: I have a template that needs to parse a list of strings as [Regex patterns](https://github.com/iamkroot/trakt-scrobbler/blob/0adca4a04854afec7df7e8b35fd583e911e2662a/trakt_scrobbler/utils.py#L187). 
* Repeatedly computing the view value according to the template is not feasible in the hot path, so I have to settle with doing a [`view.get(template)`](https://github.com/iamkroot/trakt-scrobbler/blob/0adca4a04854afec7df7e8b35fd583e911e2662a/trakt_scrobbler/file_info.py#L13-L16) in the global scope once when the module loads.
* My app is meant to be used as a long running service. Whenever the user changes a config value externally (via a cli), they have to restart the service to have their change registered, because of the limitation above.
* It would be good if the updated value could be reflected immediately from the next access of the view.

## Insight
The main pattern to notice is that we are extremely likely to use the same template to parse any given view over time. Once we decide the specific template for a view, we want to keep calling `get` with the same template over and over again (in case the value has changed).

## Method
This calls for the introduction of a caching layer that can store the values for expensive templates. In most cases, the config `get`s are much more frequent than `set`s, so it will benefit from such caching.

## API
* The PR adds a new subclass of `ConfigView`, called the `CachedConfigView`.
* The main addition to it is the `get_handle(self, template)` method. Instead of computing the value of the view according to the given template eagerly, it returns a `CachedConfigHandle` object that can be used as a proxy for the value. 
* In the first call to `get` on a `CachedConfigHandle`, the template is applied to the view, and the value is stored internally. All subsequent `get`s can re-use this cached value.
* When the view is updated from elsewhere, all handle objects for that view are automatically invalidated, and the next call to `get` on them will cause a re-computation of the value.
* Note that we still retain the ability to call `get` directly on a `view` for cases when the caching doesn't make sense (cheap to compute values).

## Example
To view this in action, see the [`ipc` branch](https://github.com/iamkroot/trakt-scrobbler/blob/7202dba586a5d1f5fdaca8e6729dfbb9216e7120/trakt_scrobbler/file_info.py) of my app.
You can also get an overview of the API from the unit tests.

## TODO
This is just a draft PR, tailored to my specific use-case. I am sure I will have missed some edge cases.
- [x] The nomenclature of `invalidate` and `unset` is misleading, and does not fit the usual meanings - an invalidated cache is usually supposed to be fixable by performing a recomputation, but that is `unset` here. The `invalidated` here means the underlying view itself has been rendered invalid, probably because some of its parents' values changed without preserving the structure. Need to find better names for these. (Can't tackle both [the hard things in Computer Science](https://martinfowler.com/bliki/TwoHardThings.html) at once 😮‍💨)
- [x] Need to add more docs/comments
- [ ] Add more test cases
- [x] Fix type hints; make them Py2 compatible maybe?
- [ ] Do we really need a `get_handle` on the `RootView`?
- [ ] Probably need to make it thread-safe

I will be happy to clean it up after an initial review from your end.

## Related
This PR is kind of the other half of #130. Once this is done, I probably will need to solve the "persist changes to disk" problem too.