### PR TITLE
Drop support for Python <3.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-      name: '${{ matrix.os }}: ${{ matrix.tox-env }}'
+      name: '${{ matrix.os }}: ${{ matrix.python-version }}'
       runs-on: ${{ matrix.os }}
       strategy:
         matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,57 +1,36 @@
 name: Build
 
 on:
-    push:
-        branches:
-           - master
-    pull_request:
-        branches:
-            - master
+  push:
+    branches:
+     - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
-    test:
-        name: '${{ matrix.os }}: ${{ matrix.tox-env }}'
-        runs-on: ${{ matrix.os }}
-        strategy:
-            matrix:
-                tox-env: [py36-test,
-                          py37-test, py38-test, pypy-test]
-                os: [ubuntu-latest, windows-latest]
+  test:
+      name: '${{ matrix.os }}: ${{ matrix.tox-env }}'
+      runs-on: ${{ matrix.os }}
+      strategy:
+        matrix:
+          python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
+          os: [ubuntu-latest, windows-latest]
 
-                # Only test on a couple of versions on Windows.
-                exclude:
-                    - os: windows-latest
-                      tox-env: py36-test
-                    - os: windows-latest
-                      tox-env: py37-test
-                    - os: windows-latest
-                      tox-env: pypy-test
+      steps:
+        - uses: actions/checkout@v3
+        - name: Set up Python ${{ matrix.python-version }}
+          uses: actions/setup-python@v4
+          with:
+            python-version: ${{ matrix.python-version }}
+        - name: Install Tox
+          run: pip install tox
+        - name: Tox
+          run: tox -e py-test
 
-                # Python interpreter versions. :/
-                include:
-                    - tox-env: py36-test
-                      python: 3.6
-                    - tox-env: py37-test
-                      python: 3.7
-                    - tox-env: py38-test
-                      python: 3.8
-                    - tox-env: pypy-test
-                      python: pypy3
-
-        steps:
-            - uses: actions/checkout@v2
-            - name: Set up Python ${{ matrix.python }}
-              uses: actions/setup-python@v2
-              with:
-                  python-version: ${{ matrix.python }}
-            - name: Install Tox
-              run: pip install tox
-            - name: Tox
-              run: tox -e ${{ matrix.tox-env }}
-
-    style:
-        name: Style
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: TrueBrain/actions-flake8@master
+  style:
+    name: Style
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: TrueBrain/actions-flake8@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,12 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                tox-env: [py27-test, py35-test, py36-test,
+                tox-env: [py36-test,
                           py37-test, py38-test, pypy-test]
                 os: [ubuntu-latest, windows-latest]
 
                 # Only test on a couple of versions on Windows.
                 exclude:
-                    - os: windows-latest
-                      tox-env: py35-test
                     - os: windows-latest
                       tox-env: py36-test
                     - os: windows-latest
@@ -31,10 +29,6 @@ jobs:
 
                 # Python interpreter versions. :/
                 include:
-                    - tox-env: py27-test
-                      python: 2.7
-                    - tox-env: py35-test
-                      python: 3.5
                     - tox-env: py36-test
                       python: 3.6
                     - tox-env: py37-test

--- a/confuse/__init__.py
+++ b/confuse/__init__.py
@@ -3,7 +3,7 @@
 
 from __future__ import division, absolute_import, print_function
 
-__version__ = '1.7.0'
+__version__ = '2.0.0'
 
 from .exceptions import * # NOQA
 from .util import * # NOQA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,23 +11,13 @@ requires = [
     "pyyaml"
 ]
 description-file = "README.rst"
-requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
+requires-python = ">=3.6, <4"
 classifiers = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
-]
-
-[tool.flit.metadata.requires-extra]
-test = [
-    "pathlib; python_version == '2.7'"
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ logging-clear-handlers=1
 eval-attr="!=slow"
 
 [flake8]
-min-version=2.7
+min-version=3.6
 # Default pyflakes errors we ignore:
 # - E241: missing whitespace after ',' (used to align visually)
 # - E221: multiple spaces before operator (used to align visually)

--- a/test/test_paths.py
+++ b/test/test_paths.py
@@ -172,9 +172,9 @@ class PrimaryConfigDirTest(FakeSystem):
         def join(self, *args):
             return self.os_path.normpath(self.os_path.join(*args))
 
-        def makedirs(self, path, *args):
+        def makedirs(self, path, *args, **kwargs):
             os.path, os_path = self.os_path, os.path
-            self._makedirs(path, *args)
+            self._makedirs(path, *args, **kwargs)
             os.path = os_path
 
     def setUp(self):

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,7 @@ basepython = python3
 
 [_test]
 deps =
-    coverage
-    nose
-    nose-show-skipped
+    nose2[coverage_plugin]
     pyyaml
     pathlib
 
@@ -27,14 +25,12 @@ deps =
 files = example confuse test docs
 
 [testenv]
-passenv =
-    NOSE_SHOW_SKIPPED # Undocumented feature of nose-show-skipped.
 deps =
     {test,cov}: {[_test]deps}
     py{36,37,38}-flake8: {[_flake8]deps}
 commands =
-    cov: nosetests --with-coverage {posargs}
-    test: nosetests {posargs}
+    cov: nose2 --with-coverage {posargs}
+    test: nose2 {posargs}
     py36-flake8: flake8 --min-version 3.6 {posargs} {[_flake8]files}
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,34,35,36,37,38}-test, py27-flake8, docs
+envlist = py{36,37,38}-test, py38-flake8, docs
 isolated_build = True
 
 [tox:.package]
@@ -31,17 +31,14 @@ passenv =
     NOSE_SHOW_SKIPPED # Undocumented feature of nose-show-skipped.
 deps =
     {test,cov}: {[_test]deps}
-    py{27,34,36}-flake8: {[_flake8]deps}
+    py{36,37,38}-flake8: {[_flake8]deps}
 commands =
     cov: nosetests --with-coverage {posargs}
     test: nosetests {posargs}
-    py27-flake8: flake8 --min-version 2.7 {posargs} {[_flake8]files}
-    py34-flake8: flake8 --min-version 3.4 {posargs} {[_flake8]files}
     py36-flake8: flake8 --min-version 3.6 {posargs} {[_flake8]files}
 
 [testenv:docs]
-basepython = python2.7
-deps = 
+deps =
     sphinx
     sphinx-rtd-theme
 commands = sphinx-build -W -q -b html docs {envtmpdir}/html {posargs}


### PR DESCRIPTION
It's time to move on from Python 2 and, with it, Pythons below 3.6. This is the initial work to drop the old Pythons from all our configurations. It would be a good idea to rejigger the tox setup more comprehensively and test on recent Pythons (up to 3.10).

This changes the version to 2.0.0; I think dropping interpreter support counts as a major version bump in SemVer.

Spurred by #146.