### PR TITLE
Remove some Python 2isms

### DIFF
--- a/confuse/__init__.py
+++ b/confuse/__init__.py
@@ -1,8 +1,6 @@
 """Painless YAML configuration.
 """
 
-from __future__ import division, absolute_import, print_function
-
 __version__ = '2.0.0'
 
 from .exceptions import * # NOQA

--- a/confuse/core.py
+++ b/confuse/core.py
@@ -15,8 +15,6 @@
 
 """Worry-free YAML configuration files.
 """
-from __future__ import division, absolute_import, print_function
-
 import errno
 import os
 import yaml

--- a/confuse/core.py
+++ b/confuse/core.py
@@ -165,23 +165,10 @@ class ConfigView(object):
     def __str__(self):
         """Get the value for this view as a bytestring.
         """
-        if util.PY3:
-            return self.__unicode__()
-        else:
-            return bytes(self.get())
-
-    def __unicode__(self):
-        """Get the value for this view as a Unicode string.
-        """
-        return util.STRING(self.get())
-
-    def __nonzero__(self):
-        """Gets the value for this view as a boolean. (Python 2 only.)
-        """
-        return self.__bool__()
+        return str(self.get())
 
     def __bool__(self):
-        """Gets the value for this view as a boolean. (Python 3 only.)
+        """Gets the value for this view as a bool.
         """
         return bool(self.get())
 
@@ -441,7 +428,7 @@ class Subview(ConfigView):
             self.name += u'#{0}'.format(self.key)
         elif isinstance(self.key, bytes):
             self.name += self.key.decode('utf-8')
-        elif isinstance(self.key, util.STRING):
+        elif isinstance(self.key, str):
             self.name += self.key
         else:
             self.name += repr(self.key)

--- a/confuse/exceptions.py
+++ b/confuse/exceptions.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import yaml
 
 __all__ = [

--- a/confuse/sources.py
+++ b/confuse/sources.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 from .util import build_dict
 from . import yaml_util
 import os

--- a/confuse/sources.py
+++ b/confuse/sources.py
@@ -1,6 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-from .util import BASESTRING, build_dict
+from .util import build_dict
 from . import yaml_util
 import os
 
@@ -27,8 +27,7 @@ class ConfigSource(dict):
         behavior.
         """
         super(ConfigSource, self).__init__(value)
-        if (filename is not None
-                and not isinstance(filename, BASESTRING)):
+        if filename is not None and not isinstance(filename, str):
             raise TypeError(u'filename must be a string or None')
         self.filename = filename
         self.default = default

--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -2,27 +2,12 @@ from __future__ import division, absolute_import, print_function
 
 import os
 import re
-import sys
+import enum
+import pathlib
+from collections import abc
 
 from . import util
 from . import exceptions
-
-try:
-    import enum
-    SUPPORTS_ENUM = True
-except ImportError:
-    SUPPORTS_ENUM = False
-
-try:
-    import pathlib
-    SUPPORTS_PATHLIB = True
-except ImportError:
-    SUPPORTS_PATHLIB = False
-
-if sys.version_info >= (3, 3):
-    from collections import abc
-else:
-    import collections as abc
 
 
 REQUIRED = object()
@@ -130,7 +115,7 @@ class Number(Template):
     def convert(self, value, view):
         """Check that the value is an int or a float.
         """
-        if isinstance(value, util.NUMERIC_TYPES):
+        if isinstance(value, (int, float)):
             return value
         else:
             self.fail(
@@ -243,7 +228,7 @@ class String(Template):
     def convert(self, value, view):
         """Check that the value is a string and matches the pattern.
         """
-        if not isinstance(value, util.BASESTRING):
+        if not isinstance(value, str):
             self.fail(u'must be a string', view, True)
 
         if self.pattern and not self.regex.match(value):
@@ -278,7 +263,7 @@ class Choice(Template):
         """Ensure that the value is among the choices (and remap if the
         choices are a mapping).
         """
-        if (SUPPORTS_ENUM and isinstance(self.choices, type)
+        if (isinstance(self.choices, type)
                 and issubclass(self.choices, enum.Enum)):
             try:
                 return self.choices(value)
@@ -385,7 +370,7 @@ class StrSeq(Template):
         self.split = split
 
     def _convert_value(self, x, view):
-        if isinstance(x, util.STRING):
+        if isinstance(x, str):
             return x
         elif isinstance(x, bytes):
             return x.decode('utf-8', 'ignore')
@@ -396,7 +381,7 @@ class StrSeq(Template):
         if isinstance(value, bytes):
             value = value.decode('utf-8', 'ignore')
 
-        if isinstance(value, util.STRING):
+        if isinstance(value, str):
             if self.split:
                 value = value.split()
             else:
@@ -566,13 +551,13 @@ class Filename(Template):
         except exceptions.NotFoundError:
             return self.get_default_value(view.name)
 
-        if not isinstance(path, util.BASESTRING):
+        if not isinstance(path, str):
             self.fail(
                 u'must be a filename, not {0}'.format(type(path).__name__),
                 view,
                 True
             )
-        path = os.path.expanduser(util.STRING(path))
+        path = os.path.expanduser(str(path))
 
         if not os.path.isabs(path):
             if self.cwd is not None:
@@ -602,9 +587,6 @@ class Path(Filename):
 
     Filenames are parsed equivalent to the `Filename` template and then
     converted to `pathlib.Path` objects.
-
-    For Python 2 it returns the original path as returned by the `Filename`
-    template.
     """
     def value(self, view, template=None):
         value = super(Path, self).value(view, template)
@@ -709,15 +691,14 @@ def as_template(value):
         return Integer()
     elif isinstance(value, int):
         return Integer(value)
-    elif isinstance(value, type) and issubclass(value, util.BASESTRING):
+    elif isinstance(value, type) and issubclass(value, str):
         return String()
-    elif isinstance(value, util.BASESTRING):
+    elif isinstance(value, str):
         return String(value)
     elif isinstance(value, set):
         # convert to list to avoid hash related problems
         return Choice(list(value))
-    elif (SUPPORTS_ENUM and isinstance(value, type)
-            and issubclass(value, enum.Enum)):
+    elif isinstance(value, type) and issubclass(value, enum.Enum):
         return Choice(value)
     elif isinstance(value, list):
         return OneOf(value)
@@ -725,7 +706,7 @@ def as_template(value):
         return Number()
     elif isinstance(value, float):
         return Number(value)
-    elif SUPPORTS_PATHLIB and isinstance(value, pathlib.PurePath):
+    elif isinstance(value, pathlib.PurePath):
         return Path(value)
     elif value is None:
         return Template(None)

--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import os
 import re
 import enum

--- a/confuse/util.py
+++ b/confuse/util.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import os
 import sys
 import argparse

--- a/confuse/util.py
+++ b/confuse/util.py
@@ -8,12 +8,6 @@ import platform
 import pkgutil
 
 
-PY3 = sys.version_info[0] == 3
-STRING = str if PY3 else unicode  # noqa: F821
-BASESTRING = str if PY3 else basestring  # noqa: F821
-NUMERIC_TYPES = (int, float) if PY3 else (int, float, long)  # noqa: F821
-
-
 UNIX_DIR_FALLBACK = '~/.config'
 WINDOWS_DIR_VAR = 'APPDATA'
 WINDOWS_DIR_FALLBACK = '~\\AppData\\Roaming'
@@ -75,7 +69,7 @@ def build_dict(obj, sep='', keep_none=False):
         return obj
 
     # Get keys iterator
-    keys = obj.keys() if PY3 else obj.iterkeys()
+    keys = obj.keys()
     if sep:
         # Splitting keys by `sep` needs sorted keys to prevent parents
         # from clobbering children

--- a/confuse/yaml_util.py
+++ b/confuse/yaml_util.py
@@ -3,7 +3,6 @@ from __future__ import division, absolute_import, print_function
 from collections import OrderedDict
 import yaml
 from .exceptions import ConfigReadError
-from .util import BASESTRING
 
 # YAML loading.
 
@@ -119,7 +118,7 @@ def parse_as_scalar(value, loader=Loader):
       - The empty string '' will return None
     """
     # We only deal with strings
-    if not isinstance(value, BASESTRING):
+    if not isinstance(value, str):
         return value
     try:
         loader = loader('')

--- a/confuse/yaml_util.py
+++ b/confuse/yaml_util.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 from collections import OrderedDict
 import yaml
 from .exceptions import ConfigReadError

--- a/example/__init__.py
+++ b/example/__init__.py
@@ -1,5 +1,4 @@
 """An example application using Confuse for configuration."""
-from __future__ import division, absolute_import, print_function
 import confuse
 import argparse
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,13 +10,6 @@ min-version=3.6
 # - E221: multiple spaces before operator (used to align visually)
 # - E731: do not assign a lambda expression, use a def
 # - C901: function/method complexity
-# `flake8-future-import` errors we ignore:
-# - FI50: `__future__` import "division" present
-# - FI51: `__future__` import "absolute_import" present
-# - FI12: `__future__` import "with_statement" missing
-# - FI53: `__future__` import "print_function" present
-# - FI14: `__future__` import "unicode_literals" missing
-# - FI15: `__future__` import "generator_stop" missing
 # pycodestyle warnings ignored:
 # - W503: line breaks before binary operators
-ignore=C901,E241,E221,E731,FI50,FI51,FI12,FI53,FI14,FI15,W503
+ignore=C901,E241,E221,E731,W503

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import confuse
 import tempfile
 import shutil

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import confuse
 import argparse
 from argparse import Namespace

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import confuse
 import textwrap
 import unittest

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import confuse
 import os
 import unittest

--- a/test/test_paths.py
+++ b/test/test_paths.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import confuse
 import confuse.yaml_util
 import ntpath

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 from argparse import Namespace
 from collections import OrderedDict
 import confuse

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 try:
     import enum
     SUPPORTS_ENUM = True

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -115,18 +115,6 @@ class AsTemplateTest(unittest.TestCase):
         self.assertIsInstance(typ, confuse.String)
         self.assertEqual(typ.default, 'foo')
 
-    @unittest.skipIf(confuse.PY3, "unicode only present in Python 2")
-    def test_unicode_type_as_template(self):
-        typ = confuse.as_template(unicode)  # noqa ignore=F821
-        self.assertIsInstance(typ, confuse.String)
-        self.assertEqual(typ.default, confuse.REQUIRED)
-
-    @unittest.skipIf(confuse.PY3, "basestring only present in Python 2")
-    def test_basestring_as_template(self):
-        typ = confuse.as_template(basestring)  # noqa ignore=F821
-        self.assertIsInstance(typ, confuse.String)
-        self.assertEqual(typ.default, confuse.REQUIRED)
-
     def test_dict_as_template(self):
         typ = confuse.as_template({'key': 9})
         self.assertIsInstance(typ, confuse.MappingTemplate)

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -121,11 +121,6 @@ class BuiltInValidatorTest(unittest.TestCase):
         config = _root({'i': 2})
         config['i'].as_number()
 
-    @unittest.skipIf(confuse.PY3, "long only present in Python 2")
-    def test_as_number_long_in_py2(self):
-        config = _root({'l': long(3)})  # noqa ignore=F821
-        config['l'].as_number()
-
     def test_as_number_string(self):
         config = _root({'s': 'a'})
         with self.assertRaises(confuse.ConfigTypeError):

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 try:
     import enum
     SUPPORTS_ENUM = True

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -1,11 +1,8 @@
 from __future__ import division, absolute_import, print_function
 
 import confuse
-import sys
 import unittest
 from . import _root
-
-PY3 = sys.version_info[0] == 3
 
 
 class SingleSourceTest(unittest.TestCase):
@@ -100,12 +97,6 @@ class ConverstionTest(unittest.TestCase):
         config = _root({'foo': 2})
         value = str(config['foo'])
         self.assertEqual(value, '2')
-
-    @unittest.skipIf(confuse.PY3, "unicode only present in Python 2")
-    def test_unicode_conversion_from_int(self):
-        config = _root({'foo': 2})
-        value = unicode(config['foo'])  # noqa ignore=F821
-        self.assertEqual(value, unicode('2'))  # noqa ignore=F821
 
     def test_bool_conversion_from_bool(self):
         config = _root({'foo': True})

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import confuse
 import unittest
 from . import _root

--- a/test/test_yaml.py
+++ b/test/test_yaml.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import confuse
 import yaml
 import unittest

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ deps =
 [_flake8]
 deps =
     flake8
-    flake8-future-import
     pep8-naming
 files = example confuse test docs
 


### PR DESCRIPTION
As a followup to #147, this removes the Python 2 compatibility hacks we had sprinkled throughout the codebase.