### PR TITLE
Remove <4 requirement for Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires = [
     "pyyaml"
 ]
 description-file = "README.rst"
-requires-python = ">=3.6, <4"
+requires-python = ">=3.6"
 classifiers = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Remove the <4 upper bound from the Python requirements.

This will prevent downstream projects that use [poetry](https://github.com/python-poetry/poetry) from having to set <4 as an upper bound for Python.

Closes https://github.com/beetbox/confuse/issues/153