### PR TITLE
docs: Add readthedocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+  - requirements: docs/requirements.txt


### PR DESCRIPTION
This should fix missing API docs.

Fixes: #158

Test build at https://jmennius-confuse.readthedocs.io/en/latest/api.html