### PR TITLE
docs: Mention Choice's Enum support in published docs, publish __init__ docs

### DIFF
--- a/confuse/core.py
+++ b/confuse/core.py
@@ -307,6 +307,9 @@ class ConfigView(object):
     def as_choice(self, choices):
         """Get the value from a list of choices. Equivalent to
         `get(Choice(choices))`.
+
+        Sequences, dictionaries and :class:`Enum` types are supported,
+        see :class:`confuse.templates.Choice` for more details.
         """
         return self.get(templates.Choice(choices))
 

--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -243,6 +243,9 @@ class String(Template):
 
 class Choice(Template):
     """A template that permits values from a sequence of choices.
+
+    Sequences, dictionaries and :class:`Enum` types are supported,
+    see :meth:`__init__` for usage.
     """
     def __init__(self, choices, default=REQUIRED):
         """Create a template that validates any of the values from the

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,6 +34,7 @@ Templates
 .. automodule:: confuse.templates
     :members:
     :private-members:
+    :special-members: __init__
     :show-inheritance:
 
 Utility


### PR DESCRIPTION
The fact that `Choice`/`as_choice()` support working with `Enum`s was not visible in built/published documentation - fix this.