### PR TITLE
Read default config before user config

### DIFF
--- a/confuse/core.py
+++ b/confuse/core.py
@@ -534,10 +534,10 @@ class Configuration(RootView):
         discovered user configuration files or the in-package defaults,
         set `user` or `defaults` to `False`.
         """
-        if user:
-            self._add_user_source()
         if defaults:
             self._add_default_source()
+        if user:
+            self._add_user_source()
 
     def config_dir(self):
         """Get the path to the user configuration directory. The


### PR DESCRIPTION
The method `Configuration.read()` currently loads configuration files in this order:

1. User configuration file (`config.yaml`)
2. Default configuration file (`config_default.yaml`)

This load order means that any values in the user configuration file are replaced by the default configuration file in the module. As a result, the user cannot override values in config.yaml.

The user configuration should take precedence and should be loaded second.