### PR TITLE
Use xdg_config_home on unix instead of hard-coded path

### DIFF
--- a/confuse/util.py
+++ b/confuse/util.py
@@ -4,9 +4,10 @@ import argparse
 import optparse
 import platform
 import pkgutil
+from xdg import BaseDirectory
 
 
-UNIX_DIR_FALLBACK = '~/.config'
+UNIX_DIR_FALLBACK = BaseDirectory.xdg_config_home
 WINDOWS_DIR_VAR = 'APPDATA'
 WINDOWS_DIR_FALLBACK = '~\\AppData\\Roaming'
 MAC_DIR = '~/Library/Application Support'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=2,<4"]
+requires = ["flit_core >=2,<4", "pyxdg >= 0.28,<0.30"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]
@@ -9,6 +9,7 @@ author-email = "adrian@radbox.org"
 home-page = "https://github.com/beetbox/confuse"
 requires = [
     "pyyaml"
+    "pyxdg"
 ]
 description-file = "README.rst"
 requires-python = ">=3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=2,<4", "pyxdg >= 0.28,<0.30"]
+requires = ["flit_core >=2,<4"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyYAML
+pyxdg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 PyYAML
-pyxdg


### PR DESCRIPTION
This should fix a [bug](https://github.com/beetbox/beets/issues/5507) where `XDG_CONFIG_HOME` is ignored by beet.