### PR TITLE
remove version detection for enum module

### DIFF
--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -1,15 +1,6 @@
-try:
-    import enum
-    SUPPORTS_ENUM = True
-except ImportError:
-    SUPPORTS_ENUM = False
-
-try:
-    from collections.abc import Mapping, Sequence
-except ImportError:
-    from collections import Mapping, Sequence
-
+from collections.abc import Mapping, Sequence
 import confuse
+import enum
 import os
 import unittest
 from . import _root
@@ -138,8 +129,6 @@ class AsTemplateTest(unittest.TestCase):
         typ = confuse.as_template(set())
         self.assertIsInstance(typ, confuse.Choice)
 
-    @unittest.skipUnless(SUPPORTS_ENUM,
-                         "enum not supported in this version of Python.")
     def test_enum_type_as_template(self):
         typ = confuse.as_template(enum.Enum)
         self.assertIsInstance(typ, confuse.Choice)

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -1,10 +1,5 @@
-try:
-    import enum
-    SUPPORTS_ENUM = True
-except ImportError:
-    SUPPORTS_ENUM = False
-
 import confuse
+import enum
 import os
 import unittest
 from . import _root
@@ -91,8 +86,6 @@ class BuiltInValidatorTest(unittest.TestCase):
         })
         self.assertEqual(res, 'baz')
 
-    @unittest.skipUnless(SUPPORTS_ENUM,
-                         "enum not supported in this version of Python.")
     def test_as_choice_with_enum(self):
         class Foobar(enum.Enum):
             Foo = 'bar'
@@ -101,8 +94,6 @@ class BuiltInValidatorTest(unittest.TestCase):
         res = config['foo'].as_choice(Foobar)
         self.assertEqual(res, Foobar.Foo)
 
-    @unittest.skipUnless(SUPPORTS_ENUM,
-                         "enum not supported in this version of Python.")
     def test_as_choice_with_enum_error(self):
         class Foobar(enum.Enum):
             Foo = 'bar'


### PR DESCRIPTION
which was added in Python 3.4, but the minimum Python version we still claim to support is 3.6