### PR TITLE
Added typehints to the as_* helpers.

### DIFF
--- a/confuse/core.py
+++ b/confuse/core.py
@@ -17,6 +17,13 @@
 """
 from __future__ import annotations
 
+__all__ = [
+    'CONFIG_FILENAME', 'DEFAULT_FILENAME', 'ROOT_NAME', 'REDACTED_TOMBSTONE',
+    'ConfigView', 'RootView', 'Subview', 'Configuration',
+    'ConfigSource', 'EnvSource', 'YamlSource',
+    'ConfigTypeError', 'NotFoundError', 'ConfigError',
+]
+
 import errno
 import os
 from pathlib import Path
@@ -715,10 +722,3 @@ class LazyConfig(Configuration):
 
 
 # "Validated" configuration views: experimental!
-
-__all__ = [
-    'CONFIG_FILENAME', 'DEFAULT_FILENAME', 'ROOT_NAME', 'REDACTED_TOMBSTONE',
-    'ConfigView', 'RootView', 'Subview', 'Configuration',
-    'ConfigSource', 'EnvSource', 'YamlSource',
-    'ConfigTypeError', 'NotFoundError', 'ConfigError',
-]

--- a/confuse/core.py
+++ b/confuse/core.py
@@ -713,3 +713,10 @@ class LazyConfig(Configuration):
 
 
 # "Validated" configuration views: experimental!
+
+__all__ = [
+    'CONFIG_FILENAME', 'DEFAULT_FILENAME', 'ROOT_NAME', 'REDACTED_TOMBSTONE',
+    'ConfigView', 'RootView', 'Subview', 'Configuration',
+    'ConfigSource', 'EnvSource', 'YamlSource',
+    'ConfigTypeError', 'NotFoundError', 'ConfigError',
+]

--- a/confuse/core.py
+++ b/confuse/core.py
@@ -17,6 +17,8 @@
 """
 import errno
 import os
+from pathlib import Path
+from typing import Any, Iterable, Sequence, TypeVar
 import yaml
 from collections import OrderedDict
 
@@ -32,6 +34,7 @@ ROOT_NAME = 'root'
 
 REDACTED_TOMBSTONE = 'REDACTED'
 
+R = TypeVar('R')
 
 # Views and sources.
 
@@ -277,7 +280,7 @@ class ConfigView():
                     od[key] = view.get()
         return od
 
-    def get(self, template=templates.REQUIRED):
+    def get(self, template=templates.REQUIRED) -> Any:
         """Retrieve the value for this view according to the template.
 
         The `template` against which the values are checked can be
@@ -294,17 +297,17 @@ class ConfigView():
 
     # Shortcuts for common templates.
 
-    def as_filename(self):
+    def as_filename(self) -> str:
         """Get the value as a path. Equivalent to `get(Filename())`.
         """
         return self.get(templates.Filename())
 
-    def as_path(self):
+    def as_path(self) -> Path:
         """Get the value as a `pathlib.Path` object. Equivalent to `get(Path())`.
         """
         return self.get(templates.Path())
 
-    def as_choice(self, choices):
+    def as_choice(self, choices: Iterable[R]) -> R:
         """Get the value from a list of choices. Equivalent to
         `get(Choice(choices))`.
 
@@ -313,31 +316,31 @@ class ConfigView():
         """
         return self.get(templates.Choice(choices))
 
-    def as_number(self):
+    def as_number(self) -> int | float:
         """Get the value as any number type: int or float. Equivalent to
         `get(Number())`.
         """
         return self.get(templates.Number())
 
-    def as_str_seq(self, split=True):
+    def as_str_seq(self, split=True) -> Sequence[str]:
         """Get the value as a sequence of strings. Equivalent to
         `get(StrSeq(split=split))`.
         """
         return self.get(templates.StrSeq(split=split))
 
-    def as_pairs(self, default_value=None):
+    def as_pairs(self, default_value=None) -> Sequence[tuple[str, str]]:
         """Get the value as a sequence of pairs of two strings. Equivalent to
         `get(Pairs(default_value=default_value))`.
         """
         return self.get(templates.Pairs(default_value=default_value))
 
-    def as_str(self):
+    def as_str(self) -> str:
         """Get the value as a (Unicode) string. Equivalent to
         `get(unicode)` on Python 2 and `get(str)` on Python 3.
         """
         return self.get(templates.String())
 
-    def as_str_expanded(self):
+    def as_str_expanded(self) -> str:
         """Get the value as a (Unicode) string, with env vars
         expanded by `os.path.expandvars()`.
         """
@@ -381,8 +384,8 @@ class RootView(ConfigView):
         self.name = ROOT_NAME
         self.redactions = set()
 
-    def add(self, obj):
-        self.sources.append(ConfigSource.of(obj))
+    def add(self, value):
+        self.sources.append(ConfigSource.of(value=value))
 
     def set(self, value):
         self.sources.insert(0, ConfigSource.of(value))

--- a/confuse/core.py
+++ b/confuse/core.py
@@ -15,6 +15,8 @@
 
 """Worry-free YAML configuration files.
 """
+from __future__ import annotations
+
 import errno
 import os
 from pathlib import Path


### PR DESCRIPTION
# Summary
This PR adds minimal type hints to the `as_*` helper functions.

# Why
These additions improve the developer experience by enabling better support from type inference tools such as Pylance. In particular, it prevents false-positive errors or missing type information on `as_*` lines during development.
