### PR TITLE
Fix StopIteration in restore_yaml_comments when default_data ends with a comment or blank line

### DIFF
--- a/confuse/yaml_util.py
+++ b/confuse/yaml_util.py
@@ -226,18 +226,19 @@ def restore_yaml_comments(data: str, default_data: str) -> str:
             comment = f"{line}\n"
         else:
             continue
+        found_key = False
         while True:
             try:
                 line = next(default_lines)
             except StopIteration:
                 # File ends with a comment or blank line and no following key;
                 # discard the accumulated comment and stop scanning.
-                line = None
                 break
             if line and not line.startswith("#"):
+                found_key = True
                 break
             comment += f"{line}\n"
-        if line is None:
+        if not found_key:
             break
         key = line.split(":")[0].strip()
         comment_map[key] = comment

--- a/confuse/yaml_util.py
+++ b/confuse/yaml_util.py
@@ -227,10 +227,18 @@ def restore_yaml_comments(data: str, default_data: str) -> str:
         else:
             continue
         while True:
-            line = next(default_lines)
+            try:
+                line = next(default_lines)
+            except StopIteration:
+                # File ends with a comment or blank line and no following key;
+                # discard the accumulated comment and stop scanning.
+                line = None
+                break
             if line and not line.startswith("#"):
                 break
             comment += f"{line}\n"
+        if line is None:
+            break
         key = line.split(":")[0].strip()
         comment_map[key] = comment
     out_lines = iter(data.splitlines())

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ----------
 
+- Fix ``restore_yaml_comments`` crashing when default data ends with a comment
+  or blank line. [#148](https://github.com/beetbox/confuse/issues/148)
+
 v2.2.1
 ------
 

--- a/test/test_yaml.py
+++ b/test/test_yaml.py
@@ -5,6 +5,7 @@ import pytest
 import yaml
 
 import confuse
+from confuse.yaml_util import restore_yaml_comments
 
 from . import TempDir
 
@@ -114,3 +115,30 @@ class ParseAsScalarTest(unittest.TestCase):
     def test_invalid_yaml_string_unchanged(self):
         v = confuse.yaml_util.parse_as_scalar("!", confuse.Loader)
         assert v == "!"
+
+
+class RestoreYamlCommentsTest(unittest.TestCase):
+    def test_trailing_comment_does_not_raise(self):
+        """restore_yaml_comments must not raise StopIteration when
+        default_data ends with a comment line (issue #148)."""
+        default_data = "key1: value1\n# trailing comment\n"
+        data = "key1: value1\n"
+        # Must complete without raising StopIteration
+        result = restore_yaml_comments(data, default_data)
+        assert "key1: value1" in result
+
+    def test_trailing_blank_line_does_not_raise(self):
+        """restore_yaml_comments must not raise StopIteration when
+        default_data ends with a blank line (issue #148)."""
+        default_data = "key1: value1\n\n"
+        data = "key1: value1\n"
+        result = restore_yaml_comments(data, default_data)
+        assert "key1: value1" in result
+
+    def test_comments_still_restored_before_key(self):
+        """Comments before a key in default_data are prepended to that key
+        in the output."""
+        default_data = "# Comment for key1\nkey1: value1\n"
+        data = "key1: value1\n"
+        result = restore_yaml_comments(data, default_data)
+        assert result == "# Comment for key1\nkey1: value1\n"


### PR DESCRIPTION
## What

`restore_yaml_comments` in `confuse/yaml_util.py` uses a bare `next()` call inside an inner `while True` loop to scan past comment or blank lines in `default_data`. If the file ends on a comment or blank line — which is extremely common, since editors and most YAML files append a trailing newline after the last comment — `next()` raises `StopIteration`, which propagates out of the function entirely and crashes any caller.

The most visible symptom: `Configuration.dump()` raises `StopIteration` when the application's `config_default.yaml` has an empty or comment-only last line (issue #148).

## Root cause

```python
while True:
    line = next(default_lines)   # raises StopIteration at EOF, no catch
    ...
```

## Fix

Wrap the `next()` call in a `try/except StopIteration`, set `line = None`, and break out of both the inner and outer loops. The trailing comment is silently discarded (there is no following key to attach it to), matching the documented behaviour for orphaned comments.

## Tests

Three regression tests added to `test/test_yaml.py`:

- `test_trailing_comment_does_not_raise` — default_data ends with `# trailing comment`
- `test_trailing_blank_line_does_not_raise` — default_data ends with `\n\n`
- `test_comments_still_restored_before_key` — verifies normal comment restoration still works

All 295 existing tests continue to pass.

Closes #148.

---

This pull request was prepared with the assistance of AI, under my direction and review.