### PR TITLE
Resolve optional Path correctly

### DIFF
--- a/confuse/__init__.py
+++ b/confuse/__init__.py
@@ -4,5 +4,6 @@ from .core import *  # noqa: F403
 from .exceptions import *  # noqa: F403
 from .sources import *  # noqa: F403
 from .templates import *  # noqa: F403
+from .templates import Path as Path
 from .util import *  # type: ignore[no-redef] # noqa: F403
 from .yaml_util import *  # noqa: F403

--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
 K = TypeVar("K", bound=Hashable, default=str)
-P = TypeVar("P", bound=pathlib.PurePath | str, default=str)
+P = TypeVar("P", bound=pathlib.Path | str, default=str)
 V = TypeVar("V", default=object)
 ConfigKey = int | str | bytes
 ConfigKeyT = TypeVar("ConfigKeyT", bound=ConfigKey, default=str)
@@ -738,7 +738,7 @@ class Filename(Template[P]):
         return os.path.abspath(path_str)
 
 
-class Path(Filename[pathlib.PurePath]):
+class Path(Filename[pathlib.Path]):
     """A template that validates strings as `pathlib.Path` objects.
 
     Filenames are parsed equivalent to the `Filename` template and then
@@ -863,7 +863,7 @@ def as_template(value: set[T]) -> Choice[T, T]: ...
 @overload
 def as_template(value: list[T]) -> OneOf[T]: ...
 @overload
-def as_template(value: pathlib.PurePath) -> Path: ...
+def as_template(value: pathlib.Path) -> Path: ...
 @overload
 def as_template(value: None) -> Template[None]: ...
 @overload
@@ -897,7 +897,7 @@ def as_template(value: Any) -> Template[Any]:
         return Number()
     elif isinstance(value, float):
         return Number(value)
-    elif isinstance(value, pathlib.PurePath):
+    elif isinstance(value, pathlib.Path):
         return Path(value)
     elif value is None:
         return Template(None)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Unreleased
 
 - Require `typing_extensions` on older Python versions (and use `typing` on
   newer versions). [#189](https://github.com/beetbox/confuse/issues/189)
+- Narrow `Path` template shorthand handling to concrete `pathlib.Path` values
+  for more accurate type checking.
 
 v2.2.0
 ------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ Unreleased
   newer versions). [#189](https://github.com/beetbox/confuse/issues/189)
 - Narrow `Path` template shorthand handling to concrete `pathlib.Path` values
   for more accurate type checking.
+- Fix `confuse.Path` which now points to `confuse.templates.Path` instead of
+  `pathlib.Path`.
 
 v2.2.0
 ------

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -1,10 +1,16 @@
 import enum
 import os
+import pathlib
 import unittest
 from collections.abc import Mapping, Sequence
 from typing import Any
 
 import pytest
+
+try:
+    from typing import assert_type  # type: ignore[attr-defined]
+except ImportError:  # Python < 3.11
+    from typing_extensions import assert_type
 
 import confuse
 
@@ -461,18 +467,19 @@ class FilenameTest(unittest.TestCase):
 
 class PathTest(unittest.TestCase):
     def test_path_value(self):
-        import pathlib
-
         config = _root({"foo": "foo/bar"})
         valid = config["foo"].get(confuse.Path())
         assert valid == pathlib.Path(os.path.abspath("foo/bar"))
 
     def test_default_value(self):
-        import pathlib
-
         config = _root({})
         valid = config["foo"].get(confuse.Path("foo/bar"))
         assert valid == pathlib.Path("foo/bar")
+
+    def test_optional_value_type(self):
+        config = _root({"foo": "foo/bar"})
+        valid = config["foo"].get(confuse.Optional(confuse.Path()))
+        assert_type(valid, pathlib.Path | None)
 
     def test_default_none(self):
         config = _root({})


### PR DESCRIPTION
I was adding types to beetsplug/fetchart.py and found that this

```py
@cached_property
def fallback(self) -> Path | None:
    return self.config["fallback"].get(
        confuse.Optional(confuse.templates.Path())
    )
```

fails with

```
beetsplug/fetchart.py:1370: error: Incompatible return value type (got "PurePath | None", expected "Path | None")  [return-value]
```
