### PR TITLE
Preserve list structure when setting a list index

### DIFF
--- a/confuse/core.py
+++ b/confuse/core.py
@@ -156,7 +156,7 @@ class ConfigView:
         """Create an overlay source to assign a given key under this
         view.
         """
-        self.set({key: value})
+        self[key].set(value)
 
     def __contains__(self, key: ConfigKey) -> bool:
         return self[key].exists()
@@ -486,6 +486,20 @@ class Subview(ConfigView):
             yield value, source
 
     def set(self, value: Any) -> None:
+        if isinstance(self.key, int):
+            # The parent is (or may be) a list. Overriding it with a
+            # dict of {index: value} would replace the whole sequence
+            # with an integer-keyed mapping, so rebuild the list
+            # instead, with only this index replaced.
+            for collection, _ in self.parent.resolve():
+                if isinstance(collection, list) and -len(collection) <= self.key < len(
+                    collection
+                ):
+                    new_collection = list(collection)
+                    new_collection[self.key] = value
+                    self.parent.set(new_collection)
+                    return
+                break
         self.parent.set({self.key: value})
 
     def add(self, value: Any) -> None:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 Unreleased
 ----------
 
+- Fix setting a value at a list index, which replaced the containing list with
+  an integer-keyed mapping.
+  [#169](https://github.com/beetbox/confuse/issues/169)
+
 v2.2.1
 ------
 

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -276,3 +276,13 @@ class SetTest(unittest.TestCase):
         config = _root({"foo": ["a", "b", "c"]})
         config["foo"][1] = "bar"
         assert config["foo"][1].get() == "bar"
+
+    def test_override_list_index_keeps_list(self):
+        config = _root({"foo": ["a", "b", "c"]})
+        config["foo"][1] = "bar"
+        assert config["foo"].get() == ["a", "bar", "c"]
+
+    def test_override_nested_list_index_keeps_list(self):
+        config = _root({"foo": [{"name": "a"}, {"name": "b"}]})
+        config["foo"][0]["name"] = "bar"
+        assert config["foo"].get() == [{"name": "bar"}, {"name": "b"}]


### PR DESCRIPTION
Closes #169

`Subview.set` overlaid `{key: value}` on the parent, so setting through an integer index replaced the containing list with an integer-keyed mapping: `config["stages"][0]["name"].set(x)` turned `stages` into `{0: {"name": x}}`. It now rebuilds the list with only that index replaced when the parent resolves to a list, and `__setitem__` routes through the subview so item assignment takes the same path.

Regression tests added for the flat and nested cases; they fail on the previous behaviour. Full suite: 295 passed, 3 skipped.
