### PR TITLE
Include default value in Choice template repr

### DIFF
--- a/confuse/templates.py
+++ b/confuse/templates.py
@@ -387,7 +387,12 @@ class Choice(Template[T], Generic[T, K]):
             )
 
     def __repr__(self) -> str:
-        return f"Choice({self.choices!r})"
+        args = [repr(self.choices)]
+
+        if self.default is not REQUIRED:
+            args.append(repr(self.default))
+
+        return f"Choice({', '.join(args)})"
 
 
 class OneOf(Template[T]):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+- Include the default value in the `Choice` template repr. [#201](https://github.com/beetbox/confuse/issues/201)
 v2.2.1
 ------
 

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -257,6 +257,12 @@ class ChoiceTest(unittest.TestCase):
         with pytest.raises(confuse.ConfigValueError):
             config["foo"].get(confuse.Choice({2: "two", 4: "four"}))
 
+    def test_repr_without_default(self):
+        assert repr(confuse.Choice([1, 2])) == "Choice([1, 2])"
+
+    def test_repr_includes_default(self):
+        assert repr(confuse.Choice([1, 2], 2)) == "Choice([1, 2], 2)"
+
 
 class OneOfTest(unittest.TestCase):
     def test_default_value(self):


### PR DESCRIPTION
Closes #127

`Choice.__repr__` only rendered the choices, so `Choice([1, 2], 2)` and `Choice([1, 2])` printed identically. It now appends the default when one is set, matching how `String`, `OneOf` and `Filename` already build their reprs.