### PR TITLE
Add `as_optional_path` accessor

### DIFF
--- a/confuse/core.py
+++ b/confuse/core.py
@@ -331,6 +331,10 @@ class ConfigView:
         """Get the value as a `pathlib.Path` object. Equivalent to `get(Path())`."""
         return self.get(templates.Path())
 
+    def as_optional_path(self) -> Path | None:
+        """Get the value as a `pathlib.Path` object or `None`."""
+        return self.get(templates.Optional(templates.Path()))
+
     def as_choice(self, choices: Sequence[R] | dict[str, R] | type[R]) -> R:
         """Get the value from a list of choices. Equivalent to
         `get(Choice(choices))`.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ----------
 
+- Add an ``as_optional_path`` accessor for optional path configuration values.
+
 v2.2.1
 ------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,3 +138,8 @@ ignore = [
 
 [tool.ruff.format]
 quote-style = "double"
+
+[tool.ruff.lint.flake8-pytest-style]
+fixture-parentheses = false
+mark-parentheses = false
+parametrize-names-type = "csv"

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -1,5 +1,6 @@
 import enum
 import os
+import pathlib
 import unittest
 
 import pytest
@@ -31,7 +32,7 @@ class TypeCheckTest(unittest.TestCase):
             config["foo"].get(int)
 
 
-class BuiltInValidatorTest(unittest.TestCase):
+class TestBuiltInValidator:
     def test_as_filename_with_non_file_source(self):
         config = _root({"foo": "foo/bar"})
         value = config["foo"].as_filename()
@@ -61,15 +62,22 @@ class BuiltInValidatorTest(unittest.TestCase):
     def test_as_path(self):
         config = _root({"foo": "foo/bar"})
         path_str = os.path.join(os.getcwd(), "foo", "bar")
-        try:
-            import pathlib
-        except ImportError:
-            with pytest.raises(ImportError):
-                value = config["foo"].as_path()
-        else:
-            value = config["foo"].as_path()
-            path = pathlib.Path(path_str)
-            assert value == path
+        value = config["foo"].as_path()
+        path = pathlib.Path(path_str)
+        assert value == path
+
+    @pytest.mark.parametrize(
+        "config, expected_value",
+        [
+            ({"foo": "foo/bar"}, pathlib.Path(os.getcwd(), "foo", "bar")),
+            ({"foo": None}, None),
+            ({}, None),
+        ],
+    )
+    def test_as_optional_path(self, config, expected_value):
+        config = _root(config)
+        value = config["foo"].as_optional_path()
+        assert value == expected_value
 
     def test_as_choice_correct(self):
         config = _root({"foo": "bar"})


### PR DESCRIPTION
As I've been migrating `beets` to `pathlib` I realised that I use this pattern a lot:

```py
$ grep -RiC1 'Optional.*Path' beets*
beetsplug/convert.py-    def tmpdir(self) -> Path | None:
beetsplug/convert.py:        return self.config["tmpdir"].get(confuse.Optional(confuse.Path()))
beetsplug/convert.py-
--
beetsplug/duplicates.py-        checksum = self.config["checksum"].get(str)
beetsplug/duplicates.py:        copy = self.config["copy"].get(confuse.Optional(confuse.Path()))
beetsplug/duplicates.py-        count = self.config["count"].get(bool)
--
beetsplug/duplicates.py-        merge = self.config["merge"].get(bool)
beetsplug/duplicates.py:        move = self.config["move"].get(confuse.Optional(confuse.Path()))
beetsplug/duplicates.py-        path = self.config["path"].get(bool)
--
beetsplug/fetchart.py-        return self.config["fallback"].get(
beetsplug/fetchart.py:            confuse.Optional(confuse.templates.Path())
beetsplug/fetchart.py-        )
--
beetsplug/importfeeds.py-        if feeds_dir := self.config["dir"].get(
beetsplug/importfeeds.py:            confuse.Optional(confuse.Path())
beetsplug/importfeeds.py-        ):
--
beetsplug/importfeeds.py-        if relative_to := self.config["relative_to"].get(
beetsplug/importfeeds.py:            confuse.Optional(confuse.Path())
beetsplug/importfeeds.py-        ):
--
beetsplug/play.py-        if relative_to := config["play"]["relative_to"].get(
beetsplug/play.py:            confuse.Optional(confuse.Path())
beetsplug/play.py-        ):
--
beetsplug/smartplaylist.py-        if relative_to := self.config["relative_to"].get(
beetsplug/smartplaylist.py:            confuse.Optional(confuse.Path())
beetsplug/smartplaylist.py-        ):
```
